### PR TITLE
Add flash screen to project

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'screens/all_historical.dart';
 import 'screens/all_mountain.dart';
 import 'screens/all_village.dart';
 import 'screens/all_wild_life.dart';
+import 'screens/splash_screen.dart';
 
 void main() {
   runApp(MyApp());
@@ -83,7 +84,7 @@ class MyApp extends StatelessWidget {
       ),
       initialRoute: '/',
       routes: {
-        '/': (context) => WelcomePage(),
+        '/': (context) => SplashScreen(),
         '/signup': (context) => SignUpPage(),
         '/signin': (context) => SignInPage(),
         '/home': (context) => HomePage(),

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'welcome_page.dart';
+
+class SplashScreen extends StatefulWidget {
+  @override
+  _SplashScreenState createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Timer(Duration(seconds: 3), () {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => WelcomePage()),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Image.asset('lib/assets/splash_image.png'), // Replace with your splash image path
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Add a splash screen to the project.

* Create a new file `lib/screens/splash_screen.dart` with a `SplashScreen` widget.
* Import necessary packages and `welcome_page.dart` in `lib/screens/splash_screen.dart`.
* Implement a timer in `SplashScreen` to navigate to `WelcomePage` after a 3-second delay.
* Display an image in the center of the splash screen.
* Modify `lib/main.dart` to import `splash_screen.dart`.
* Set `SplashScreen` as the initial route in `MyApp` class in `lib/main.dart`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nht-dilshan/sltravel_app/pull/1?shareId=2a5d0ddf-e4f7-418f-9d5d-c6a36283b7fb).